### PR TITLE
Fix XSS risk in missing SVG placeholder title

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,5 +1,14 @@
 #!/usr/bin/env ruby
-$: << File.expand_path("../test", __dir__)
+ENV["RAILS_ENV"] ||= "test"
+$LOAD_PATH.unshift File.expand_path("../test", __dir__)
 
 require "bundler/setup"
-require "rails/plugin/test"
+require "minitest/autorun"
+
+test_files = if ARGV.empty?
+  Dir[File.expand_path("../test/**/*_test.rb", __dir__)].sort
+else
+  ARGV.map { |file| File.expand_path(file, Dir.pwd) }
+end
+
+test_files.each { |file| require file }

--- a/lib/avo/icons.rb
+++ b/lib/avo/icons.rb
@@ -12,7 +12,7 @@ module Avo
       attr_accessor :cached_svgs
 
       def root
-        Pathname.new File.expand_path('..', __dir__)
+        Pathname.new File.expand_path("..", __dir__)
       end
 
       def configuration

--- a/lib/avo/icons/configuration.rb
+++ b/lib/avo/icons/configuration.rb
@@ -21,4 +21,3 @@ module Avo
     end
   end
 end
-

--- a/lib/avo/icons/helpers.rb
+++ b/lib/avo/icons/helpers.rb
@@ -24,8 +24,9 @@ module Avo
       # https://github.com/jamesmartin/inline_svg/blob/main/lib/inline_svg/action_view/helpers.rb#L61
       def placeholder(filename)
         css_class = "avo-missing-svg"
+        escaped_filename = ERB::Util.html_escape_once(filename.to_s)
         missing_icon = '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-ice-cream-off"><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path d="M12 21.5v-4.5" /><path d="M8 8v9h8v-1m0 -4v-5a4 4 0 0 0 -7.277 -2.294" /><path d="M8 10.5l1.74 -.76m2.79 -1.222l3.47 -1.518" /><path d="M8 14.5l4.488 -1.964" /><path d="M3 3l18 18" /></svg>'
-        "<div data-tippy='tooltip' class='#{css_class}' style='width: 2rem; height: 2rem; color: #ef4444;' title='SVG file not found: #{filename}'><!-- SVG file not found: '#{ERB::Util.html_escape_once(filename)}' -->#{missing_icon}</div>".html_safe
+        "<div data-tippy='tooltip' class='#{css_class}' style='width: 2rem; height: 2rem; color: #ef4444;' title='SVG file not found: #{escaped_filename}'><!-- SVG file not found: '#{escaped_filename}' -->#{missing_icon}</div>".html_safe
       end
 
       # Taken from the original library

--- a/lib/avo/icons/helpers.rb
+++ b/lib/avo/icons/helpers.rb
@@ -41,4 +41,3 @@ module Avo
     end
   end
 end
-

--- a/lib/avo/icons/svg_finder.rb
+++ b/lib/avo/icons/svg_finder.rb
@@ -73,4 +73,3 @@ module Avo
     end
   end
 end
-

--- a/test/avo/icons/helpers_test.rb
+++ b/test/avo/icons/helpers_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class Avo::Icons::HelpersTest < ActiveSupport::TestCase
+  test "placeholder escapes filename in title and comment" do
+    helper = Class.new do
+      include Avo::Icons::Helpers
+    end.new
+
+    filename = "x' onmouseover='alert(1)"
+    output = helper.send(:placeholder, filename)
+
+    assert_includes output, "title='SVG file not found: x&#39; onmouseover=&#39;alert(1)'"
+    assert_includes output, "<!-- SVG file not found: 'x&#39; onmouseover=&#39;alert(1)' -->"
+    refute_includes output, "onmouseover='alert(1)'"
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- verified `Avo::Icons::Helpers#placeholder` interpolated raw `filename` into the `title` attribute while marking the full string as `html_safe`
- escaped `filename` once with `ERB::Util.html_escape_once(filename.to_s)` and reused the escaped value in both the `title` attribute and the HTML comment
- added a regression test that covers a filename containing single quotes and confirms no injectable raw attribute payload remains
- fixed CI lint failures called out on the PR by:
  - removing trailing empty lines at EOF in `lib/avo/icons/helpers.rb`, `lib/avo/icons/configuration.rb`, and `lib/avo/icons/svg_finder.rb`
  - switching `File.expand_path('..', __dir__)` to double quotes in `lib/avo/icons.rb`
- fixed the failing `test` job by replacing deprecated `rails/plugin/test` usage in `bin/test` with a direct Minitest runner that loads all `test/**/*_test.rb` files (or explicit paths from args)

## Testing
- local execution is blocked in this cloud environment because Ruby/Bundler are unavailable (`ruby` and `bundle` commands not found)
- validated failure cause from CI logs (`cannot load such file -- rails/plugin/test`) and patched `bin/test` accordingly
- CI should now rerun against commit `901f7e4` for full verification
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7aaf9979-21f6-45cb-b2b3-9b49ec6b1fd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aaf9979-21f6-45cb-b2b3-9b49ec6b1fd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

