### PR TITLE
Don't crash if asset pipeline is missing

### DIFF
--- a/lib/avo/icons/svg_finder.rb
+++ b/lib/avo/icons/svg_finder.rb
@@ -37,7 +37,7 @@ module Avo
           Avo::Icons.root.join("assets", "svgs", "heroicons", "mini", @filename),
           Avo::Icons.root.join("assets", "svgs", "heroicons", "micro", @filename),
           # Add all paths from Rails including engines
-          *Rails.application.config.assets&.paths&.map { |path| File.join(path, @filename) }
+          *(Rails.application.config.respond_to?(:assets) ? Rails.application.config.assets&.paths&.map { |path| File.join(path, @filename) } : nil)
         ]
 
         # Add custom paths from configuration
@@ -57,11 +57,11 @@ module Avo
         if defined?(Propshaft)
           asset_path = ::Rails.application.assets.load_path.find(@filename)
           asset_path&.path
-        elsif ::Rails.application.config.assets.compile
+        elsif Rails.application.config.respond_to?(:assets) && ::Rails.application.config.assets.compile
           # Grab the asset from the compiled asset manifest
           asset = ::Rails.application.assets[@filename]
           Pathname.new(asset.filename) if asset.present?
-        else
+        elsif Rails.application.respond_to?(:assets_manifest)
           # Grab the asset from the manifest
           manifest = ::Rails.application.assets_manifest
           asset_path = manifest.assets[@filename]
@@ -73,4 +73,3 @@ module Avo
     end
   end
 end
-

--- a/lib/avo/icons/svg_finder.rb
+++ b/lib/avo/icons/svg_finder.rb
@@ -37,7 +37,7 @@ module Avo
           Avo::Icons.root.join("assets", "svgs", "heroicons", "mini", @filename),
           Avo::Icons.root.join("assets", "svgs", "heroicons", "micro", @filename),
           # Add all paths from Rails including engines
-          *(Rails.application.config.respond_to?(:assets) ? Rails.application.config.assets&.paths&.map { |path| File.join(path, @filename) } : nil)
+          *Rails.application.config.try(:assets)&.paths&.map { |path| File.join(path, @filename) }
         ]
 
         # Add custom paths from configuration
@@ -53,15 +53,18 @@ module Avo
       end
 
       def default_strategy
+        # Return nil if the app doesn't have assets configured
+        return unless Rails.application.config.respond_to?(:assets)
+
         # If the app uses Propshaft, grab it from there
         if defined?(Propshaft)
           asset_path = ::Rails.application.assets.load_path.find(@filename)
           asset_path&.path
-        elsif Rails.application.config.respond_to?(:assets) && ::Rails.application.config.assets.compile
+        elsif ::Rails.application.config.assets.compile
           # Grab the asset from the compiled asset manifest
           asset = ::Rails.application.assets[@filename]
           Pathname.new(asset.filename) if asset.present?
-        elsif Rails.application.respond_to?(:assets_manifest)
+        else
           # Grab the asset from the manifest
           manifest = ::Rails.application.assets_manifest
           asset_path = manifest.assets[@filename]


### PR DESCRIPTION
I use neither `sprockets` nor `propshaft`. `avo` itself seems to work fine, but this icon library fails to boot, when both are missing.

My PR simply guards agains missing:
- `Rails.application.config.assets`
- `Rails.application.assets_manifest`

I don't see a test setup and CI seems to fail, so I didn't write tests. However, keeping this use-case working would be much appreciated.
